### PR TITLE
check for undefined test object in hooks

### DIFF
--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -52,6 +52,9 @@ export default class InsightsHandler {
     }
 
     async beforeHook (test: Frameworks.Test, context: any) {
+        if (!test) {
+            return
+        }
         const fullTitle = `${test.parent} - ${test.title}`
         const hookId = uuidv4()
         this._tests[fullTitle] = {
@@ -65,6 +68,9 @@ export default class InsightsHandler {
     }
 
     async afterHook (test: Frameworks.Test, result: Frameworks.TestResult) {
+        if (!test) {
+            return
+        }
         const fullTitle = getUniqueIdentifier(test)
         if (this._tests[fullTitle]) {
             this._tests[fullTitle].finishedAt = (new Date()).toISOString()

--- a/packages/wdio-browserstack-service/tests/insights-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/insights-handler.test.ts
@@ -419,6 +419,11 @@ describe('beforeHook', () => {
         expect(insightsHandler['_tests']).toEqual({ 'parent - test': { uuid: '123456789', startedAt: '2020-01-01T00:00:00.000Z' } })
         expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
     })
+
+    it('return if test data is empty', async () => {
+        await insightsHandler.beforeHook( undefined as any, {} as any)
+        expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(0)
+    })
 })
 
 describe('afterHook', () => {
@@ -447,6 +452,11 @@ describe('afterHook', () => {
         await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any)
         expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
         expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
+    })
+
+    it('return if test data is empty', async () => {
+        await insightsHandler.afterHook( undefined as any, {} as any)
+        expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(0)
     })
 })
 


### PR DESCRIPTION
For certain user defined hooks like beforeAll and afterAll in cucumber, the test argument being passed to beforeHook and afterHook is undefined. Leading to exception
```
[0-0] 2023-03-06T17:13:57.110Z ERROR @wdio/utils:shim: TypeError: Cannot read properties of undefined (reading 'parent')
[0-0]     at InsightsHandler.beforeHook (/Users/sean.darley/projects/dig-navigation-ui-search/test/node_modules/@wdio/browserstack-service/build/insights-handler.js:39:35)
```

## Proposed changes
As a part of this PR we are checking for undefined value in order to avoid exceptions.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
