### PR TITLE
chore: check for mocha in hook

### DIFF
--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -52,28 +52,28 @@ export default class InsightsHandler {
     }
 
     async beforeHook (test: Frameworks.Test, context: any) {
-        const fullTitle = `${test.parent} - ${test.title}`
-        const hookId = uuidv4()
-        this._tests[fullTitle] = {
-            uuid: hookId,
-            startedAt: (new Date()).toISOString()
-        }
-        this.attachHookData(context, hookId)
         if (this._framework === 'mocha') {
+            const fullTitle = `${test.parent} - ${test.title}`
+            const hookId = uuidv4()
+            this._tests[fullTitle] = {
+                uuid: hookId,
+                startedAt: (new Date()).toISOString()
+            }
+            this.attachHookData(context, hookId)
             await this.sendTestRunEvent(test, 'HookRunStarted')
         }
     }
 
     async afterHook (test: Frameworks.Test, result: Frameworks.TestResult) {
-        const fullTitle = getUniqueIdentifier(test)
-        if (this._tests[fullTitle]) {
-            this._tests[fullTitle].finishedAt = (new Date()).toISOString()
-        } else {
-            this._tests[fullTitle] = {
-                finishedAt: (new Date()).toISOString()
-            }
-        }
         if (this._framework === 'mocha') {
+            const fullTitle = getUniqueIdentifier(test)
+            if (this._tests[fullTitle]) {
+                this._tests[fullTitle].finishedAt = (new Date()).toISOString()
+            } else {
+                this._tests[fullTitle] = {
+                    finishedAt: (new Date()).toISOString()
+                }
+            }
             await this.sendTestRunEvent(test, 'HookRunFinished', result)
         }
     }

--- a/packages/wdio-browserstack-service/tests/insights-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/insights-handler.test.ts
@@ -401,52 +401,94 @@ describe('beforeTest', () => {
 describe('beforeHook', () => {
     let insightsHandler
 
-    beforeEach(() => {
-        insightsHandler = new InsightsHandler(browser, false, 'framework')
-        insightsHandler['sendTestRunEvent'] = vi.fn().mockImplementation(() => { return [] })
-        insightsHandler['attachHookData'] = vi.fn().mockImplementation(() => { return [] })
-        insightsHandler['_tests'] = {}
-        insightsHandler['_framework'] = 'mocha'
+    describe('mocha', () => {
+        beforeEach(() => {
+            insightsHandler = new InsightsHandler(browser, false, 'framework')
+            insightsHandler['sendTestRunEvent'] = vi.fn().mockImplementation(() => { return [] })
+            insightsHandler['attachHookData'] = vi.fn().mockImplementation(() => { return [] })
+            insightsHandler['_tests'] = {}
+            insightsHandler['_framework'] = 'mocha'
+        })
+
+        beforeEach(() => {
+            vi.mocked(insightsHandler['sendTestRunEvent']).mockClear()
+            vi.mocked(insightsHandler['attachHookData']).mockClear()
+        })
+
+        it('update hook data', async () => {
+            await insightsHandler.beforeHook({ parent: 'parent', title: 'test' } as any, {} as any)
+            expect(insightsHandler['_tests']).toEqual({ 'parent - test': { uuid: '123456789', startedAt: '2020-01-01T00:00:00.000Z' } })
+            expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
+        })
     })
 
-    beforeEach(() => {
-        vi.mocked(insightsHandler['sendTestRunEvent']).mockClear()
-        vi.mocked(insightsHandler['attachHookData']).mockClear()
-    })
+    describe('cucumber', () => {
+        beforeEach(() => {
+            insightsHandler = new InsightsHandler(browser, false, 'framework')
+            insightsHandler['sendTestRunEvent'] = vi.fn().mockImplementation(() => { return [] })
+            insightsHandler['attachHookData'] = vi.fn().mockImplementation(() => { return [] })
+            insightsHandler['_tests'] = {}
+            insightsHandler['_framework'] = 'cucumber'
+        })
 
-    it('update hook data', async () => {
-        await insightsHandler.beforeHook({ parent: 'parent', title: 'test' } as any, {} as any)
-        expect(insightsHandler['_tests']).toEqual({ 'parent - test': { uuid: '123456789', startedAt: '2020-01-01T00:00:00.000Z' } })
-        expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
+        beforeEach(() => {
+            vi.mocked(insightsHandler['sendTestRunEvent']).mockClear()
+            vi.mocked(insightsHandler['attachHookData']).mockClear()
+        })
+
+        it('doesn\'t update hook data', async () => {
+            await insightsHandler.beforeHook(undefined as any, {} as any)
+            expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(0)
+        })
     })
 })
 
 describe('afterHook', () => {
     let insightsHandler
 
-    beforeEach(() => {
-        insightsHandler = new InsightsHandler(browser, false, 'mocha')
-        insightsHandler['sendTestRunEvent'] = vi.fn().mockImplementation(() => { return [] })
-        insightsHandler['attachHookData'] = vi.fn().mockImplementation(() => { return [] })
+    describe('mocha', () => {
+        beforeEach(() => {
+            insightsHandler = new InsightsHandler(browser, false, 'mocha')
+            insightsHandler['sendTestRunEvent'] = vi.fn().mockImplementation(() => { return [] })
+            insightsHandler['attachHookData'] = vi.fn().mockImplementation(() => { return [] })
 
-        vi.spyOn(utils, 'getUniqueIdentifier').mockReturnValue('test title')
-        vi.spyOn(utils, 'getUniqueIdentifierForCucumber').mockReturnValue('test title')
-        vi.mocked(insightsHandler['sendTestRunEvent']).mockClear()
-        vi.mocked(insightsHandler['attachHookData']).mockClear()
+            vi.spyOn(utils, 'getUniqueIdentifier').mockReturnValue('test title')
+            vi.spyOn(utils, 'getUniqueIdentifierForCucumber').mockReturnValue('test title')
+            vi.mocked(insightsHandler['sendTestRunEvent']).mockClear()
+            vi.mocked(insightsHandler['attachHookData']).mockClear()
+        })
+
+        it('add hook data', async () => {
+            insightsHandler['_tests'] = {}
+            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any)
+            expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
+            expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
+        })
+
+        it('update hook data', async () => {
+            insightsHandler['_tests'] = { 'test title': {} }
+            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any)
+            expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
+            expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
+        })
     })
 
-    it('add hook data', async () => {
-        insightsHandler['_tests'] = {}
-        await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any)
-        expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
-        expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
-    })
+    describe('cucumber', () => {
+        beforeEach(() => {
+            insightsHandler = new InsightsHandler(browser, false, 'cucumber')
+            insightsHandler['sendTestRunEvent'] = vi.fn().mockImplementation(() => { return [] })
+            insightsHandler['attachHookData'] = vi.fn().mockImplementation(() => { return [] })
 
-    it('update hook data', async () => {
-        insightsHandler['_tests'] = { 'test title': {} }
-        await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any)
-        expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
-        expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(1)
+            vi.spyOn(utils, 'getUniqueIdentifier').mockReturnValue('test title')
+            vi.spyOn(utils, 'getUniqueIdentifierForCucumber').mockReturnValue('test title')
+            vi.mocked(insightsHandler['sendTestRunEvent']).mockClear()
+            vi.mocked(insightsHandler['attachHookData']).mockClear()
+        })
+
+        it('doesn\'t update hook data', async () => {
+            await insightsHandler.afterHook(undefined as any, {} as any)
+            expect(insightsHandler['sendTestRunEvent']).toBeCalledTimes(0)
+        })
     })
 })
 


### PR DESCRIPTION
For certain user defined hooks like beforeAll and afterAll in cucumber, the test argument being passed to beforeHook and afterHook is undefined. Leading to exception.

```
[0-0] 2023-03-06T17:13:57.110Z ERROR @wdio/utils:shim: TypeError: Cannot read properties of undefined (reading 'parent')
[0-0]     at InsightsHandler.beforeHook (/Users/sean.darley/projects/dig-navigation-ui-search/test/node_modules/@wdio/browserstack-service/build/insights-handler.js:39:35)
```

## Proposed changes
As a part of this PR we are checking for framework mocha explicitly for which the above logic works fine, and skip sending data for other frameworks. We'll tackle other frameworks on a case by case basis and unblock users from running cucumber test for now.

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
