### PR TITLE
chore: check for mocha in hook

### DIFF
--- a/packages/wdio-browserstack-service/src/insights-handler.ts
+++ b/packages/wdio-browserstack-service/src/insights-handler.ts
@@ -46,26 +46,30 @@ export default class InsightsHandler {
     }
 
     async beforeHook (test: Frameworks.Test, context: any) {
-        const fullTitle = `${test.parent} - ${test.title}`
-        const hookId = uuidv4()
-        this._tests[fullTitle] = {
-            uuid: hookId,
-            startedAt: (new Date()).toISOString()
+        if (this._framework == 'mocha') {
+            const fullTitle = `${test.parent} - ${test.title}`
+            const hookId = uuidv4()
+            this._tests[fullTitle] = {
+                uuid: hookId,
+                startedAt: (new Date()).toISOString()
+            }
+            this.attachHookData(context, hookId)
+            await this.sendTestRunEvent(test, 'HookRunStarted')
         }
-        this.attachHookData(context, hookId)
-        if (this._framework == 'mocha') await this.sendTestRunEvent(test, 'HookRunStarted')
     }
 
     async afterHook (test: Frameworks.Test, result: Frameworks.TestResult) {
-        const fullTitle = getUniqueIdentifier(test)
-        if (this._tests[fullTitle]) {
-            this._tests[fullTitle].finishedAt = (new Date()).toISOString()
-        } else {
-            this._tests[fullTitle] = {
-                finishedAt: (new Date()).toISOString()
+        if (this._framework == 'mocha') {
+            const fullTitle = getUniqueIdentifier(test)
+            if (this._tests[fullTitle]) {
+                this._tests[fullTitle].finishedAt = (new Date()).toISOString()
+            } else {
+                this._tests[fullTitle] = {
+                    finishedAt: (new Date()).toISOString()
+                }
             }
+            await this.sendTestRunEvent(test, 'HookRunFinished', result)
         }
-        if (this._framework == 'mocha') await this.sendTestRunEvent(test, 'HookRunFinished', result)
     }
 
     async beforeTest (test: Frameworks.Test) {

--- a/packages/wdio-browserstack-service/tests/insight-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/insight-handler.test.ts
@@ -478,23 +478,45 @@ describe('beforeHook', () => {
     const sendSpy = jest.spyOn(insightsHandler, 'sendTestRunEvent').mockImplementation(() => { return [] })
     const attachHookDataSpy = jest.spyOn(insightsHandler, 'attachHookData').mockImplementation(() => { return [] })
 
-    insightsHandler['_tests'] = {}
-    insightsHandler['_framework'] = 'mocha'
+    describe('mocha', () => {
+        insightsHandler['_tests'] = {}
+        insightsHandler['_framework'] = 'mocha'
 
-    beforeEach(() => {
-        sendSpy.mockClear()
-        attachHookDataSpy.mockClear()
+        beforeEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+        })
+
+        afterEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+        })
+
+        it('update hook data', async () => {
+            await insightsHandler.beforeHook({ parent: 'parent', title: 'test' } as any, {} as any)
+            expect(insightsHandler['_tests']).toEqual({ 'parent - test': { uuid: '123456789', startedAt: '2020-01-01T00:00:00.000Z' } })
+            expect(sendSpy).toBeCalledTimes(1)
+        })
     })
 
-    afterEach(() => {
-        sendSpy.mockClear()
-        attachHookDataSpy.mockClear()
-    })
+    describe('cucumber', () => {
+        insightsHandler['_tests'] = {}
+        insightsHandler['_framework'] = 'cucumber'
 
-    it('update hook data', async () => {
-        await insightsHandler.beforeHook({ parent: 'parent', title: 'test' } as any, {} as any)
-        expect(insightsHandler['_tests']).toEqual({ 'parent - test': { uuid: '123456789', startedAt: '2020-01-01T00:00:00.000Z' } })
-        expect(sendSpy).toBeCalledTimes(1)
+        beforeEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+        })
+
+        afterEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+        })
+
+        it('doesn\'t update hook data', async () => {
+            await insightsHandler.beforeHook(undefined as any, {} as any)
+            expect(sendSpy).toBeCalledTimes(0)
+        })
     })
 })
 
@@ -505,34 +527,60 @@ describe('afterHook', () => {
     const getUniqueIdentifierSpy = jest.spyOn(utils, 'getUniqueIdentifier').mockReturnValue('test title')
     const getUniqueIdentifierForCucumberSpy = jest.spyOn(utils, 'getUniqueIdentifierForCucumber').mockReturnValue('test title')
 
-    insightsHandler['_framework'] = 'mocha'
+    describe('mocha', () => {
+        insightsHandler['_framework'] = 'mocha'
 
-    beforeEach(() => {
-        sendSpy.mockClear()
-        attachHookDataSpy.mockClear()
-        getUniqueIdentifierForCucumberSpy.mockClear()
-        getUniqueIdentifierSpy.mockClear()
+        beforeEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+            getUniqueIdentifierForCucumberSpy.mockClear()
+            getUniqueIdentifierSpy.mockClear()
+        })
+
+        it('add hook data', async () => {
+            insightsHandler['_tests'] = {}
+            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any, {} as any)
+            expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
+            expect(sendSpy).toBeCalledTimes(1)
+        })
+
+        it('update hook data', async () => {
+            insightsHandler['_tests'] = { 'test title': {} }
+            await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any, {} as any)
+            expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
+            expect(sendSpy).toBeCalledTimes(1)
+        })
+
+        afterEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+            getUniqueIdentifierForCucumberSpy.mockClear()
+            getUniqueIdentifierSpy.mockClear()
+        })
     })
 
-    it('add hook data', async () => {
-        insightsHandler['_tests'] = {}
-        await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any, {} as any)
-        expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
-        expect(sendSpy).toBeCalledTimes(1)
-    })
+    describe('cucumber', () => {
+        insightsHandler['_framework'] = 'cucumber'
 
-    it('update hook data', async () => {
-        insightsHandler['_tests'] = { 'test title': {} }
-        await insightsHandler.afterHook({ parent: 'parent', title: 'test' } as any, {} as any, {} as any)
-        expect(insightsHandler['_tests']).toEqual({ 'test title': { finishedAt: '2020-01-01T00:00:00.000Z', } })
-        expect(sendSpy).toBeCalledTimes(1)
-    })
+        beforeEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+            getUniqueIdentifierForCucumberSpy.mockClear()
+            getUniqueIdentifierSpy.mockClear()
+        })
 
-    afterEach(() => {
-        sendSpy.mockClear()
-        attachHookDataSpy.mockClear()
-        getUniqueIdentifierForCucumberSpy.mockClear()
-        getUniqueIdentifierSpy.mockClear()
+        it('doesn\'t update hook data', async () => {
+            insightsHandler['_tests'] = { 'test title': {} }
+            await insightsHandler.afterHook(undefined as any, {} as any, {} as any)
+            expect(sendSpy).toBeCalledTimes(0)
+        })
+
+        afterEach(() => {
+            sendSpy.mockClear()
+            attachHookDataSpy.mockClear()
+            getUniqueIdentifierForCucumberSpy.mockClear()
+            getUniqueIdentifierSpy.mockClear()
+        })
     })
 })
 

--- a/packages/wdio-browserstack-service/tests/insight-handler.test.ts
+++ b/packages/wdio-browserstack-service/tests/insight-handler.test.ts
@@ -479,10 +479,9 @@ describe('beforeHook', () => {
     const attachHookDataSpy = jest.spyOn(insightsHandler, 'attachHookData').mockImplementation(() => { return [] })
 
     describe('mocha', () => {
-        insightsHandler['_tests'] = {}
-        insightsHandler['_framework'] = 'mocha'
-
         beforeEach(() => {
+            insightsHandler['_tests'] = {}
+            insightsHandler['_framework'] = 'mocha'
             sendSpy.mockClear()
             attachHookDataSpy.mockClear()
         })
@@ -500,10 +499,9 @@ describe('beforeHook', () => {
     })
 
     describe('cucumber', () => {
-        insightsHandler['_tests'] = {}
-        insightsHandler['_framework'] = 'cucumber'
-
         beforeEach(() => {
+            insightsHandler['_tests'] = {}
+            insightsHandler['_framework'] = 'cucumber'
             sendSpy.mockClear()
             attachHookDataSpy.mockClear()
         })
@@ -528,9 +526,9 @@ describe('afterHook', () => {
     const getUniqueIdentifierForCucumberSpy = jest.spyOn(utils, 'getUniqueIdentifierForCucumber').mockReturnValue('test title')
 
     describe('mocha', () => {
-        insightsHandler['_framework'] = 'mocha'
 
         beforeEach(() => {
+            insightsHandler['_framework'] = 'mocha'
             sendSpy.mockClear()
             attachHookDataSpy.mockClear()
             getUniqueIdentifierForCucumberSpy.mockClear()
@@ -560,9 +558,9 @@ describe('afterHook', () => {
     })
 
     describe('cucumber', () => {
-        insightsHandler['_framework'] = 'cucumber'
 
         beforeEach(() => {
+            insightsHandler['_framework'] = 'cucumber'
             sendSpy.mockClear()
             attachHookDataSpy.mockClear()
             getUniqueIdentifierForCucumberSpy.mockClear()


### PR DESCRIPTION
For certain user defined hooks like beforeAll and afterAll in cucumber, the test argument being passed to beforeHook and afterHook is undefined. Leading to exception

```
[0-0] 2023-03-06T17:13:57.110Z ERROR @wdio/utils:shim: TypeError: Cannot read properties of undefined (reading 'parent')
[0-0]     at InsightsHandler.beforeHook (/Users/sean.darley/projects/dig-navigation-ui-search/test/node_modules/@wdio/browserstack-service/build/insights-handler.js:39:35)
```

## Proposed changes
As a part of this PR we are checking for framework mocha explicitly for which the above logic works fine, and skip sending data for other frameworks

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [ ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/main/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have added proper type definitions for new commands (if appropriate)

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @webdriverio/project-committers
